### PR TITLE
fix(swagger): replace enum with minimum/maximum  for completed property

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -194,12 +194,11 @@
           "type": "integer",
           "title": "Task completition status",
           "description": "0 - ongoing, 1 - completed",
-          "enum": [
-            0,
-            1
-          ]
+          "minimum": 0,
+          "maximum": 1
         }
       }
     }
   }
 }
+

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -136,4 +136,6 @@ definitions:
         type: "integer"
         title: "Task completition status"
         description: "0 - ongoing, 1 - completed"
-        enum: [0, 1]
+        minimum: 0
+        maximum: 1
+


### PR DESCRIPTION
Properties of type integer do not support enum, we must use minimum and
maximum instead.